### PR TITLE
Fixes broken default blog post template

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,6 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
-date: {{ .Date.Format .Site.Params.DateFormat }}
+date: {{ now.Format .Site.Params.DateFormat }}
 description: >-
   TODO: type a description here
 author: {{ .Site.Params.Author.Name }}


### PR DESCRIPTION
`.Date` is a pre-formatted string